### PR TITLE
feat: expose label attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_labels"></a> [labels](#input\_labels) | Optional list of upto 30 labels to be added to created on the secret | `list(string)` | `[]` | no |
-| <a name="input_region"></a> [region](#input\_region) | Region where resources will be created | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Optional list of upto 30 labels to be created on the secret. Labels can be used to search for secrets in the Secrets Manager instance. | `list(string)` | `[]` | no |
+| <a name="input_region"></a> [region](#input\_region) | The region of the Secrets Manager instance. If not provided defaults to the region defined in the IBM provider configuration. | `string` | n/a | yes |
 | <a name="input_secret_group_id"></a> [secret\_group\_id](#input\_secret\_group\_id) | Secret Group ID of secret where IAM Secret will be added to, leave default (null) to add in default secret-group | `string` | `null` | no |
 | <a name="input_secrets_manager_guid"></a> [secrets\_manager\_guid](#input\_secrets\_manager\_guid) | Instance ID of Secrets Manager instance in where secret is stored | `string` | n/a | yes |
 | <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | The service endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private` | `string` | `"public"` | no |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_labels"></a> [labels](#input\_labels) | Optional list of upto 30 labels to be added to created on the secret | `list(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where resources will be created | `string` | n/a | yes |
 | <a name="input_secret_group_id"></a> [secret\_group\_id](#input\_secret\_group\_id) | Secret Group ID of secret where IAM Secret will be added to, leave default (null) to add in default secret-group | `string` | `null` | no |
 | <a name="input_secrets_manager_guid"></a> [secrets\_manager\_guid](#input\_secrets\_manager\_guid) | Instance ID of Secrets Manager instance in where secret is stored | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_labels"></a> [labels](#input\_labels) | Optional list of upto 30 labels to be created on the secret. Labels can be used to search for secrets in the Secrets Manager instance. | `list(string)` | `[]` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Optional list of up to 30 labels to be created on the secret. Labels can be used to search for secrets in the Secrets Manager instance. | `list(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region of the Secrets Manager instance. If not provided defaults to the region defined in the IBM provider configuration. | `string` | n/a | yes |
 | <a name="input_secret_group_id"></a> [secret\_group\_id](#input\_secret\_group\_id) | Secret Group ID of secret where IAM Secret will be added to, leave default (null) to add in default secret-group | `string` | `null` | no |
 | <a name="input_secrets_manager_guid"></a> [secrets\_manager\_guid](#input\_secrets\_manager\_guid) | Instance ID of Secrets Manager instance in where secret is stored | `string` | n/a | yes |

--- a/examples/complete-rotation-policy/main.tf
+++ b/examples/complete-rotation-policy/main.tf
@@ -110,6 +110,7 @@ resource "ibm_iam_service_policy" "secret_puller_policy" {
 module "dynamic_serviceid_apikey1" {
   source = "../.."
   region = local.sm_region
+  labels = var.resource_tags
   #tfsec:ignore:general-secrets-no-plaintext-exposure
   sm_iam_secret_name          = "${var.prefix}-${var.sm_iam_secret_name}"
   sm_iam_secret_description   = "Example of dynamic IAM secret / apikey" #tfsec:ignore:general-secrets-no-plaintext-exposure

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ resource "ibm_sm_iam_credentials_secret" "sm_iam_credentials_secret" {
   ttl             = var.sm_iam_secret_ttl
   reuse_api_key   = var.sm_iam_secret_api_key_persistence
   endpoint_type   = var.service_endpoints
+  labels          = var.labels
 
   ## This for_each block is NOT a loop to attach to multiple rotation blocks.
   ## This block is only used to conditionally add rotation block depending on var.sm_iam_secret_auto_rotation

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/common"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 	"gopkg.in/yaml.v3"
 )
@@ -44,6 +45,10 @@ func TestMain(m *testing.M) {
 }
 
 func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
+
+	// Get the tags
+	tags := common.GetTagsFromTravis()
+
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:            t,
 		TerraformDir:       defaultExampleTerraformDir,
@@ -53,6 +58,7 @@ func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 		TerraformVars: map[string]interface{}{
 			"existing_sm_instance_guid":   smGuid,
 			"existing_sm_instance_region": smRegion,
+			"resource_tags":               tags,
 		},
 	})
 	return options

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/common"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 	"gopkg.in/yaml.v3"
 )
@@ -45,10 +44,6 @@ func TestMain(m *testing.M) {
 }
 
 func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
-
-	// Get the tags
-	tags := common.GetTagsFromTravis()
-
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:            t,
 		TerraformDir:       defaultExampleTerraformDir,
@@ -58,7 +53,7 @@ func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 		TerraformVars: map[string]interface{}{
 			"existing_sm_instance_guid":   smGuid,
 			"existing_sm_instance_region": smRegion,
-			"resource_tags":               tags,
+			"resource_tags":               []string{prefix},
 		},
 	})
 	return options

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,12 @@ variable "sm_iam_secret_api_key_persistence" {
   default     = true
 }
 
+variable "labels" {
+  type        = list(string)
+  description = "Optional list of upto 30 labels to be added to created on the secret"
+  default     = []
+}
+
 variable "region" {
   type        = string
   description = "Region where resources will be created"

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "sm_iam_secret_api_key_persistence" {
 
 variable "labels" {
   type        = list(string)
-  description = "Optional list of upto 30 labels to be created on the secret. Labels can be used to search for secrets in the Secrets Manager instance."
+  description = "Optional list of up to 30 labels to be created on the secret. Labels can be used to search for secrets in the Secrets Manager instance."
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "sm_iam_secret_api_key_persistence" {
 
 variable "labels" {
   type        = list(string)
-  description = "Optional list of upto 30 labels to be added to created on the secret"
+  description = "Optional list of upto 30 labels to be created on the secret. Labels can be used to search for secrets in the Secrets Manager instance."
   default     = []
 }
 
 variable "region" {
   type        = string
-  description = "Region where resources will be created"
+  description = "The region of the Secrets Manager instance. If not provided defaults to the region defined in the IBM provider configuration."
 }
 
 variable "service_endpoints" {


### PR DESCRIPTION
### Description

Expose the `label` attribute of `ibm_sm_iam_credentials_secret` to enable searching of secrets within the secrets manager instance.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Add a new variable `labels`, a list of strings, for labels to be associated with the secret.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
