### PR TITLE
chore: update sm_tags to resource_tags and secrets_manager module to 2.15.0

### DIFF
--- a/examples/complete-no-rotation-policy/README.md
+++ b/examples/complete-no-rotation-policy/README.md
@@ -25,7 +25,7 @@ End to end example with the complete Secrets-Manager objects lifecycle including
 |------|--------|---------|
 | <a name="module_dynamic_serviceid_apikey1"></a> [dynamic\_serviceid\_apikey1](#module\_dynamic\_serviceid\_apikey1) | ../.. | n/a |
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform-ibm-modules/resource-group/ibm | 1.6.0 |
-| <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | terraform-ibm-modules/secrets-manager/ibm | 2.14.2 |
+| <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | terraform-ibm-modules/secrets-manager/ibm | 2.15.0 |
 | <a name="module_secrets_manager_group_acct"></a> [secrets\_manager\_group\_acct](#module\_secrets\_manager\_group\_acct) | terraform-ibm-modules/secrets-manager-secret-group/ibm | 1.5.1 |
 | <a name="module_secrets_manager_group_service"></a> [secrets\_manager\_group\_service](#module\_secrets\_manager\_group\_service) | terraform-ibm-modules/secrets-manager-secret-group/ibm | 1.5.1 |
 

--- a/examples/complete-no-rotation-policy/main.tf
+++ b/examples/complete-no-rotation-policy/main.tf
@@ -27,7 +27,7 @@ module "resource_group" {
 
 module "secrets_manager" {
   source                        = "terraform-ibm-modules/secrets-manager/ibm"
-  version                       = "2.14.2"
+  version                       = "2.15.0"
   existing_sm_instance_crn      = var.existing_sm_instance_crn
   skip_iam_authorization_policy = var.skip_iam_authorization_policy
   resource_group_id             = module.resource_group.resource_group_id
@@ -36,7 +36,7 @@ module "secrets_manager" {
   sm_service_plan               = "trial"
   allowed_network               = "private-only"
   endpoint_type                 = "private"
-  sm_tags                       = var.resource_tags
+  resource_tags                 = var.resource_tags
 }
 
 # Additional Secrets-Manager Secret-Group for SERVICE level secrets

--- a/examples/complete-rotation-policy/README.md
+++ b/examples/complete-rotation-policy/README.md
@@ -25,7 +25,7 @@ End to end example with the complete Secrets-Manager objects lifecycle including
 |------|--------|---------|
 | <a name="module_dynamic_serviceid_apikey1"></a> [dynamic\_serviceid\_apikey1](#module\_dynamic\_serviceid\_apikey1) | ../.. | n/a |
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform-ibm-modules/resource-group/ibm | 1.6.0 |
-| <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | terraform-ibm-modules/secrets-manager/ibm | 2.14.2 |
+| <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | terraform-ibm-modules/secrets-manager/ibm | 2.15.0 |
 | <a name="module_secrets_manager_group_acct"></a> [secrets\_manager\_group\_acct](#module\_secrets\_manager\_group\_acct) | terraform-ibm-modules/secrets-manager-secret-group/ibm | 1.5.1 |
 | <a name="module_secrets_manager_group_service"></a> [secrets\_manager\_group\_service](#module\_secrets\_manager\_group\_service) | terraform-ibm-modules/secrets-manager-secret-group/ibm | 1.5.1 |
 

--- a/examples/complete-rotation-policy/main.tf
+++ b/examples/complete-rotation-policy/main.tf
@@ -27,7 +27,7 @@ module "resource_group" {
 
 module "secrets_manager" {
   source                        = "terraform-ibm-modules/secrets-manager/ibm"
-  version                       = "2.14.2"
+  version                       = "2.15.0"
   existing_sm_instance_crn      = var.existing_sm_instance_crn
   skip_iam_authorization_policy = var.skip_iam_authorization_policy
   resource_group_id             = module.resource_group.resource_group_id
@@ -35,7 +35,7 @@ module "secrets_manager" {
   secrets_manager_name          = "${var.prefix}-secrets-manager"
   sm_service_plan               = "trial"
   allowed_network               = "public-and-private"
-  sm_tags                       = var.resource_tags
+  resource_tags                 = var.resource_tags
 }
 
 # Additional Secrets-Manager Secret-Group for SERVICE level secrets


### PR DESCRIPTION
### Description
The latest release [2.15.0](https://github.com/terraform-ibm-modules/terraform-ibm-secrets-manager/releases/tag/v2.15.0) of terraform-ibm-secrets-manager updates `sm_tags` to `resource_tags`. This PR updates the secrets_manager module version to 2.15.0 and updates all instances of `sm_tags` to `resource_tags` to maintain compatibility.

### Release required?

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

### Changes
- Updated terraform-ibm-secrets-manager module version to 2.15.0
- Replaced all instances of `sm_tags` with `resource_tags`

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
